### PR TITLE
Visitor count block restoration

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -377,13 +377,18 @@
           '{{ site.baseurl }}/assets/analytics.json',
           '{{ "/_data/analytics.json" | relative_url }}'
         ];
-        
-        let fetchAttempted = false;
-        
-        function tryFetch(path) {
-          if (fetchAttempted) return;
-          fetchAttempted = true;
-          
+
+        // 경로를 순차적으로 재시도 (실패 시 다음 경로로 진행)
+        let currentPathIndex = 0;
+
+        function tryFetchNext() {
+          if (currentPathIndex >= possiblePaths.length) {
+            console.log('Analytics 데이터 로드 실패: 모든 경로 시도 완료');
+            return;
+          }
+
+          const path = possiblePaths[currentPathIndex++];
+
           fetch(path)
             .then(response => {
               if (!response.ok) {
@@ -405,17 +410,12 @@
             })
             .catch(error => {
               console.log('Analytics 데이터 로드 실패:', path, error);
-              // 다른 경로 시도
-              const nextPath = possiblePaths.find(p => p !== path);
-              if (nextPath && possiblePaths.indexOf(path) < possiblePaths.length - 1) {
-                fetchAttempted = false;
-                setTimeout(() => tryFetch(nextPath), 100);
-              }
+              setTimeout(tryFetchNext, 100);
             });
         }
-        
-        // 첫 번째 경로로 시도
-        tryFetch(possiblePaths[0]);
+
+        // 첫 번째 경로부터 시도
+        tryFetchNext();
       })();
 
       // 좋아요 기능

--- a/index.html
+++ b/index.html
@@ -44,6 +44,20 @@ layout: default
       </div>
       <div class="profile-name">{{ site.title }}</div>
       <div class="profile-bio">{{ site.bio | newline_to_br }}</div>
+
+      <!-- 방문자 통계 (assets/analytics.json 기반) -->
+      <div class="profile-visitors">
+        <div class="visitor-stats-simple" aria-label="방문자 통계">
+          <div class="visitor-stats-title">방문자</div>
+          <div class="visitor-stats-numbers">
+            <span class="visitor-stat-value">전체 <span id="total-visitors">-</span></span>
+            <span class="visitor-stats-separator">|</span>
+            <span class="visitor-stat-value">오늘 <span id="today-visitors">-</span></span>
+            <span class="visitor-stats-separator">|</span>
+            <span class="visitor-stat-value">어제 <span id="yesterday-visitors">-</span></span>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- 카테고리 섹션 -->


### PR DESCRIPTION
Restore the visitor statistics display block on the home page and stabilize the analytics JSON loading logic.

The visitor count block disappeared because the necessary HTML elements (`total-visitors`, `today-visitors`, `yesterday-visitors`) were removed from `index.html`, even though the JavaScript to populate them was still present. Additionally, the JSON loading mechanism was improved to sequentially retry possible paths, making it more resilient.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d9d2f76-8ce2-47cf-931b-9f6ac6e26da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d9d2f76-8ce2-47cf-931b-9f6ac6e26da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

