### PR TITLE
Sofi 레퍼런스 표시

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,9 @@ permalink: /:year/:month/:day/:title.html
 # Markdown settings
 markdown: kramdown
 highlighter: rouge
+kramdown:
+  input: GFM
+  hard_wrap: false
 
 # Show future-dated posts
 future: true
@@ -100,4 +103,3 @@ admin:
   github_oauth:
     client_id: "Ov23lisMUemA9EpUyk3Q"  # GitHub OAuth App Client ID
     # client_secret은 서버 사이드에서만 사용하므로 여기에 저장하지 않음
-


### PR DESCRIPTION
Fix broken reference formatting in SOFI-related articles by configuring kramdown to use GFM input.

The default kramdown settings were not processing GitHub Flavored Markdown (GFM) footnotes (`[^1]`) correctly, causing them to appear as raw text instead of formatted links.

---
<a href="https://cursor.com/background-agent?bcId=bc-091c38f9-e003-4f8b-9287-d11b537f86f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-091c38f9-e003-4f8b-9287-d11b537f86f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

